### PR TITLE
Fix message drain loop in websocket hub

### DIFF
--- a/internal/chat/infrastructure/http/hub.go
+++ b/internal/chat/infrastructure/http/hub.go
@@ -416,9 +416,15 @@ func (c *Client) writePump() {
 			}
 
 			// Send queued messages in a single frame
-			for len(c.send) > 0 {
-				_, _ = w.Write([]byte("\n"))
-				_, _ = w.Write(<-c.send)
+			for {
+				select {
+				case msg := <-c.send:
+					_, _ = w.Write([]byte("\n"))
+					_, _ = w.Write(msg)
+				default:
+					// Exit the loop when the channel is empty
+					break
+				}
 			}
 
 			if err = w.Close(); err != nil {


### PR DESCRIPTION
## Summary
- drain all queued websocket messages safely

## Testing
- `go build ./...` *(fails: github.com/klauspost/compress: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841a43e9e9c83208fe3a3ebdd01e569