### PR TITLE
Fix bucket name in user store

### DIFF
--- a/internal/matchmaking/infrastructure/nats/user_store.go
+++ b/internal/matchmaking/infrastructure/nats/user_store.go
@@ -104,7 +104,7 @@ func (u *UserStore) RemoveUsers(ctx context.Context, userID ...string) error {
 func NewUserStore(ctx context.Context, js jetstream.JetStream) (*UserStore, error) {
 	// create a new kv store
 	kvstore, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
-		Bucket:  "randomtalk_matchamking_user_store",
+		Bucket:  "randomtalk_matchmaking_user_store",
 		History: 1,
 		TTL:     1 * time.Minute,
 	})

--- a/internal/matchmaking/infrastructure/nats/user_store_test.go
+++ b/internal/matchmaking/infrastructure/nats/user_store_test.go
@@ -82,7 +82,7 @@ func setupJetStream(t *testing.T) jetstream.JetStream {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		err = js.DeleteKeyValue(ctx, "randomtalk_matchamking_user_store")
+		err = js.DeleteKeyValue(ctx, "randomtalk_matchmaking_user_store")
 		require.NoError(t, err)
 
 		nc.Close()


### PR DESCRIPTION
## Summary
- fix typo in user store bucket name
- update cleanup bucket name in tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841a98d51548320826befca79018cea